### PR TITLE
Configure /etc/ssl and default dns server

### DIFF
--- a/packages/cloud-config/definition.yaml
+++ b/packages/cloud-config/definition.yaml
@@ -1,3 +1,3 @@
 name: cloud-config
 category: system
-version: "0.4.8"
+version: "0.4.9"

--- a/packages/cloud-config/yipfiles/01_defaults.yaml
+++ b/packages/cloud-config/yipfiles/01_defaults.yaml
@@ -50,6 +50,11 @@ stages:
          owner: 0
          group: 0
      - name: "Setup distro"
+       dns:
+         path: /etc/resolv.conf
+         nameservers:
+         - 8.8.8.8
+         - 1.1.1.1
        commands:
        - ln -s /usr/share/zoneinfo/UTC /etc/localtime
        - /usr/bin/systemctl enable cos-setup-reconcile.timer
@@ -57,6 +62,9 @@ stages:
        - /usr/bin/systemctl enable cos-setup-boot.service
        - /usr/bin/systemctl enable cos-setup-network.service
        - /usr/bin/systemctl mask purge-kernels
+       - mkdir /etc/ssl
+       - ln -s /var/lib/ca-certificates/pem /etc/ssl/certs
+       - ln -s /var/lib/ca-certificates/ca-bundle.pem /etc/ssl/ca-bundle.pem
        files:
         - path: /etc/shadow
           content: |


### PR DESCRIPTION
Those were required in order to make curl work.
Note: `update-ca-certificates` didn't the trick - somehow when being run at early stages seems to fail. Didn't investigated(yet)

Related to #37