### PR TITLE
Fixups to cos-upgrade

### DIFF
--- a/packages/cos/definition.yaml
+++ b/packages/cos/definition.yaml
@@ -1,6 +1,6 @@
 name: "cos"
 category: "system"
-version: "0.4.9"
+version: "0.4.9+1"
 
 packages: >-
       systemd
@@ -18,3 +18,4 @@ packages: >-
       curl
       iproute2
       nano
+      gawk

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: "0.6.2"
+version: "0.6.3+2"

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -67,11 +67,11 @@ do_format()
         STATE_NUM=3
         PASSIVE_NUM=4
         PERSISTENT_NUM=5
-        parted -s ${DEVICE} mkpart primary fat32 0% 50MB
+        parted -s ${DEVICE} mkpart primary fat32 0% 50MB # efi
         parted -s ${DEVICE} mkpart primary ext4 50MB 100MB # oem
-        parted -s ${DEVICE} mkpart primary ext4 100MB 800MB
-        parted -s ${DEVICE} mkpart primary ext4 800MB 1600MB
-        parted -s ${DEVICE} mkpart primary ext4 1600MB 100% # persistent
+        parted -s ${DEVICE} mkpart primary ext4 100MB 2100MB # active
+        parted -s ${DEVICE} mkpart primary ext4 2100MB 4100MB # passive
+        parted -s ${DEVICE} mkpart primary ext4 4100MB 100% # persistent
     else
         BOOT_NUM=
         OEM_NUM=1
@@ -79,9 +79,9 @@ do_format()
         PASSIVE_NUM=3
         PERSISTENT_NUM=4
         parted -s ${DEVICE} mkpart primary ext4 0% 50MB # oem
-        parted -s ${DEVICE} mkpart primary ext4 50MB 750MB
-        parted -s ${DEVICE} mkpart primary ext4 750MB 1500MB
-        parted -s ${DEVICE} mkpart primary ext4 1500MB 100% # persistent
+        parted -s ${DEVICE} mkpart primary ext4 50MB 2050MB # active
+        parted -s ${DEVICE} mkpart primary ext4 2050MB 4050MB # passive
+        parted -s ${DEVICE} mkpart primary ext4 4050MB 100% # persistent
     fi
 
     parted -s ${DEVICE} set 1 ${BOOTFLAG} on


### PR DESCRIPTION
Now the state partitions defaults to 2GB.
It now also detect booting partition in cos-upgrade, doing the partition switch based on the one we are booting into ( so it is idempotent)

Also, setup TMPDIR and XDG_RUNTIME_DIR until we have a persistent state partition for the update process.
TMPDIR for luet can be annotated in the config file, but temporary do it here until the process is completely fixed

Also wipe passive partition, until we get a persistent db for luet.

Add gawk to the base image, which is used in cos-upgrade

I avoided to touch the cloud-init file, to avoid any conflict, it's something that can be tweaked afterwards. Until #37 is fixed, can't really split into multiple files.

Related to #8