### PR TITLE
Bumps

### DIFF
--- a/packages/kernels/collection.yaml
+++ b/packages/kernels/collection.yaml
@@ -1,6 +1,16 @@
 packages:
 - category: "kernel"
   name: "vanilla"
-  version: "5.10.14-1.1"
+  version: "5.10.16-1.2"
   description: "Standard kernel"
-  kernel_id: "5.10.14-1-vanilla"
+  kernel_id: "5.10.16-1-vanilla"
+
+  labels:
+    autobump.revdeps: "false"
+    autobump.string_replace: '{ "prefix": "" }'
+    autobump.strategy: "custom"
+    autobump.prefix: "prefix"
+    autobump.hook: |
+            docker run -ti --rm opensuse/tumbleweed bash -c 'zypper se -v kernel-vanilla | awk "{ print \$6 }" | grep -P "\d" | uniq'
+    autobump.version_hook:
+            docker run -ti --rm opensuse/tumbleweed bash -c 'zypper se -v kernel-vanilla | awk "{ print \$6 }" | grep -P "\d" | uniq'

--- a/packages/luet/definition.yaml
+++ b/packages/luet/definition.yaml
@@ -1,6 +1,6 @@
 category: "system"
 name: "luet"
-version: "0.10.2"
+version: "0.11.1"
 labels:
   github.repo: "luet"
   github.owner: "mudler"

--- a/packages/yip/definition.yaml
+++ b/packages/yip/definition.yaml
@@ -1,6 +1,6 @@
 category: "system"
 name: "yip"
-version: "0.6.3"
+version: "0.6.4"
 labels:
   github.repo: "yip"
   github.owner: "mudler"


### PR DESCRIPTION
Luet `0.11.1` addresses some fixups found during #8 
Kernels just got another bump :roll_eyes: 