### PR TITLE
Minor fixups to cos-upgrade (2)

### DIFF
--- a/packages/cos/build.yaml
+++ b/packages/cos/build.yaml
@@ -33,7 +33,9 @@ steps:
 # In opensuse, /bin/sh is a symlink to /etc/alternatives/sh, which points to bash.
 # We don't supply etc/alternatives, so handle the symlink by ourselves
 - rm -rf /bin/sh && ln -s /usr/bin/bash /bin/sh
-
+# Grub
+- mkdir /boot/grub2/ || true
+- cp -rf grub.cfg /boot/grub2/
 unpack: true
 excludes:
 - ^/etc/shadow

--- a/packages/cos/definition.yaml
+++ b/packages/cos/definition.yaml
@@ -1,6 +1,6 @@
 name: "cos"
 category: "system"
-version: "0.4.12"
+version: "0.4.13"
 
 packages: >-
       systemd

--- a/packages/cos/grub.cfg
+++ b/packages/cos/grub.cfg
@@ -1,0 +1,23 @@
+set timeout=10
+set default=cos
+
+set fallback=fallback
+set gfxmode=auto
+set gfxpayload=keep
+insmod all_video
+insmod gfxterm
+
+menuentry "cOS" --id cos {
+  search.fs_label COS_ACTIVE root
+  set root=($root)
+  linux /boot/vmlinuz-vanilla console=tty1 root=LABEL=COS_ACTIVE panic=5
+  initrd /boot/initramfs
+}
+
+menuentry "cOS (fallback)" --id fallback {
+  search.fs_label COS_PASSIVE root
+  set root=($root)
+  linux /boot/vmlinuz-vanilla console=tty1 root=LABEL=COS_PASSIVE panic=5
+  initrd /boot/initramfs
+}
+

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: "0.6.11"
+version: "0.6.12"

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: "0.6.5"
+version: "0.6.6"

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: "0.6.6"
+version: "0.6.11"

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -158,7 +158,7 @@ do_copy()
 {
     rsync -aqz --exclude='mnt' --exclude='proc' --exclude='sys' --exclude='dev' --exclude='tmp' ${DISTRO}/ ${TARGET}
     if [ -n "$COS_INSTALL_CONFIG_URL" ]; then
-        OEM=${TARGET}/oem/02_config.yaml
+        OEM=${TARGET}/oem/99_custom.yaml
         get_url "$COS_INSTALL_CONFIG_URL" $OEM
         chmod 600 ${OEM}
     fi

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -162,6 +162,31 @@ do_copy()
         get_url "$COS_INSTALL_CONFIG_URL" $OEM
         chmod 600 ${OEM}
     fi
+    mkdir -p $TARGET/usr/local/cloud-config
+cat > $TARGET/usr/local/cloud-config/90_after_install.yaml <<EOF
+# Execute this stage in the boot phase:
+stages:
+   initramfs.after:
+     - name: "After install"
+       files:
+        - path: /etc/issue
+          content: |
+            .-----.
+            | .-. |
+            | |.| |
+            | `-' |
+            `-----'
+
+            Welcome to cOS!
+            Login with user: root, password: cos
+            To upgrade the system, run "cos-upgrade"
+            To change this message permantly on boot, see /usr/local/cloud-config/90_after_install.yaml
+          permissions: 0644
+          owner: 0
+          group: 0
+EOF
+    chmod 640 $TARGET/usr/local/cloud-config
+    chmod 640 $TARGET/usr/local/cloud-config/90_after_install.yaml
 }
 
 install_grub()

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -56,6 +56,7 @@ do_format()
         STATE=$(blkid -L COS_ACTIVE || true)
         PERSISTENT=$(blkid -L COS_PERSISTENT || true)
         PASSIVE=$(blkid -L COS_PASSIVE || true)
+        BOOT=$(blkid -L COS_GRUB || true)
         return 0
     fi
 
@@ -171,16 +172,13 @@ stages:
        files:
         - path: /etc/issue
           content: |
-            .-----.
-            | .-. |
-            | |.| |
-            | `-' |
-            `-----'
 
             Welcome to cOS!
             Login with user: root, password: cos
+
             To upgrade the system, run "cos-upgrade"
             To change this message permantly on boot, see /usr/local/cloud-config/90_after_install.yaml
+
           permissions: 0644
           owner: 0
           group: 0
@@ -194,35 +192,7 @@ install_grub()
     if [ "$COS_INSTALL_DEBUG" ]; then
         GRUB_DEBUG="cos.debug"
     fi
-
-    # FIXME: vmlinuz-vanilla needs to be a generic one. e.g. vmlinuz
-    mkdir -p ${TARGET}/boot/grub2
-    cat > ${TARGET}/boot/grub2/grub.cfg << EOF
-
-
-set timeout=10
-set default=cos
-
-set fallback=fallback
-set gfxmode=auto
-set gfxpayload=keep
-insmod all_video
-insmod gfxterm
-
-menuentry "cOS" --id cos {
-  search.fs_label COS_ACTIVE root
-  set root=(\$root)
-  linux /boot/vmlinuz-vanilla console=tty1 root=LABEL=COS_ACTIVE panic=5
-  initrd /boot/initramfs
-}
-
-menuentry "cOS (fallback)" --id fallback {
-  search.fs_label COS_PASSIVE root
-  set root=(\$root)
-  linux /boot/vmlinuz-vanilla console=tty1 root=LABEL=COS_PASSIVE panic=5
-  initrd /boot/initramfs
-}
-EOF
+ 
     if [ -z "${COS_INSTALL_TTY}" ]; then
         TTY=$(tty | sed 's!/dev/!!')
     else

--- a/packages/installer/upgrade.sh
+++ b/packages/installer/upgrade.sh
@@ -51,9 +51,20 @@ find_partitions() {
         TARGET_PARTITION=$ACTIVE
         NEW_ACTIVE=$ACTIVE
         NEW_PASSIVE=$PASSIVE
+    elif [ -z "$TARGET_PARTITION" ]; then
+        # We booted from an ISO or some else medium. We assume we want to fixup the current label
+        read -p "Could not determine current partition. Set TARGET_PARTITION, NEW_ACTIVE and NEW_PASSIVE. Otherwise assuming you want to overwrite COS_ACTIVE? [y/N] : " -n 1 -r
+        if [[ ! $REPLY =~ ^[Yy]$ ]]
+        then
+            [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
+        fi
+        TARGET_PARTITION=$ACTIVE
+        NEW_ACTIVE=$ACTIVE
+        NEW_PASSIVE=$PASSIVE
     fi
+
     if [ -z "$TARGET_PARTITION" ]; then
-        echo "Could not determine target partition"
+        echo "Could not determine target partition. Set TARGET_PARTITION, NEW_ACTIVE and NEW_PASSIVE"
         exit 1
     fi
 


### PR DESCRIPTION
This PR has mostly fixups to the installer and the upgrade script.

Mainly, for the upgrade, the interesting part is that now we update grub. As we don't have a partition holding the system state, we don't retain the grub generated files anywhere - and during upgrade it means we wipe them off too. As we don't have decided yet what  to do with those, simply recall grub update after pulling the new image into the partition for now

This also fixes some glitches noticed on first boot after the system upgrade - now seems to go rather smoothly. 

The only thing to fixup with grub now is the fallback mechanism which doesn't seems to work correctly: at least the good side of updating grub in this stage is propagating that sorta of changes too.

Relates  to  #8 

