### PR TITLE
Bump yip

### DIFF
--- a/packages/yip/build.yaml
+++ b/packages/yip/build.yaml
@@ -18,6 +18,6 @@ prelude:
 steps:
 - |
    PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \
-   cd /luetbuild/go/src/github.com/mudler/yip && CGO_ENABLED=0 go build && upx --brute -1 yip && mv yip /usr/bin/yip
+   cd /luetbuild/go/src/github.com/mudler/yip && make build-small && mv yip /usr/bin/yip
 includes:
 - /usr/bin/yip

--- a/packages/yip/definition.yaml
+++ b/packages/yip/definition.yaml
@@ -1,6 +1,6 @@
 category: "system"
 name: "yip"
-version: "0.6.4"
+version: "0.7.2"
 labels:
   github.repo: "yip"
   github.owner: "mudler"


### PR DESCRIPTION
I've just cutted a 0.7.2 of yip including a lot more functionalities which are documented [here](https://github.com/mudler/yip#configuration-reference). We can then re-use the same docs in cOS when we have a proper documentation in place. The only missing points are setting up wireless and networking, but we have to decide with what sticking first.

Fixes #39