### PR TITLE
Semplify Makefile

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,17 +38,15 @@ jobs:
 
     - name: Install deps
       run: |
-        curl https://get.mocaccino.org/luet/get_luet_root.sh | sudo sh
+        sudo -E make deps
 
     - name: Validate 🌳
       run: |
         make validate
 
     - name: Build packages 🔧
-      env:
-        SUDO: "sudo -E"
       run: |
-        make rebuild-full
+        sudo -E make build
         ls -liah $PWD/build
 
     - name: Publish to DockerHub 🚀

--- a/.github/workflows/iso.yaml
+++ b/.github/workflows/iso.yaml
@@ -22,6 +22,11 @@ jobs:
     - name: setup-docker
       uses: docker-practice/actions-setup-docker@0.0.1
 
+    - name: Install deps
+      run: |
+        sudo apt-get install -y xorriso squashfs-tools dosfstools
+        sudo -E make deps
+
     # We patch docker to use all the HD available in GH action free runners
     - name: Patch Docker Daemon data-root
       run: |
@@ -32,35 +37,22 @@ jobs:
         sudo mv "/tmp/docker.json.tmp" "${DOCKER_DAEMON_JSON}"
         sudo systemctl restart docker
 
-    - name: Install deps
-      run: |
-        sudo apt-get install -y xorriso squashfs-tools dosfstools
-        curl https://get.mocaccino.org/luet/get_luet_root.sh | sudo sh
-        sudo luet install -y repository/mocaccino-extra-stable
-        sudo luet install -y system/luet-devkit utils/jq utils/yq
-
     - name: Validate 🌳
       run: |
         make validate
 
     - name: Build packages 🔧
-      env:
-        SUDO: "sudo -E"
       run: |
-        make rebuild-full
+        sudo -E make build
         ls -liah $PWD/build
     - name: Create repository 🔧
-      env:
-        SUDO: "sudo -E"
       run: |
-        make create-repo
+        sudo -E make create-repo
         ls -liah $PWD/build
 
     - name: Build ISO 🔧
-      env:
-        SUDO: "sudo -E"
       run: |
-        make local-iso
+        sudo -E make local-iso
     - uses: actions/upload-artifact@v2
       with:
         name: ISO

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -34,15 +34,13 @@ jobs:
 
     - name: Install deps
       run: |
-        curl https://get.mocaccino.org/luet/get_luet_root.sh | sudo sh
+        sudo -E make deps
 
     - name: Validate 🌳
       run: |
         make validate
 
     - name: Build packages 🔧
-      env:
-        SUDO: "sudo -E"
       run: |
-        make rebuild-full
+        sudo -E make build
         ls -liah $PWD/build

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,25 @@
 BACKEND?=docker
 CONCURRENCY?=1
-PACKAGES?=
 
-export LUET?=/usr/bin/luet
+
+export LUET?=$(shell which luet)
 export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 DESTINATION?=$(ROOT_DIR)/build
 COMPRESSION?=zstd
+ISO_SPEC?=$(ROOT_DIR)/iso/cOS-local.yaml
 CLEAN?=false
 export TREE?=$(ROOT_DIR)/packages
 
 BUILD_ARGS?=--pull --no-spinner --only-target-package
-SUDO?=
+
 VALIDATE_OPTIONS?=-s
 ARCH?=amd64
 REPO_CACHE?=raccos/$(ARCH)
 FINAL_REPO?=raccos/releases-$(ARCH)
+
+PACKAGES?=$(shell yq r -j $(ISO_SPEC) 'packages.[*]' | jq -r '.[]' | sort -u)
+HAS_LUET := $(shell command -v luet 2> /dev/null)
+
 export REPO_CACHE
 ifneq ($(strip $(REPO_CACHE)),)
 	BUILD_ARGS+=--image-repository $(REPO_CACHE)
@@ -23,36 +28,30 @@ endif
 all: deps build
 
 deps:
-	@echo "Installing luet"
-	go get -u github.com/mudler/luet
+ifndef HAS_LUET
+ifneq ($(shell id -u), 0)
+	@echo "You must be root to perform this action."
+	exit 1
+endif
+	curl https://get.mocaccino.org/luet/get_luet_root.sh |  sh
+	luet install -y repository/mocaccino-extra-stable
+	luet install -y utils/jq utils/yq system/luet-devkit
+endif
 
 clean:
-	$(SUDO) rm -rf build/ *.tar *.metadata.yaml
+	 rm -rf build/
 
 .PHONY: build
-build: clean
-	mkdir -p $(ROOT_DIR)/build
-	$(SUDO) $(LUET) build $(BUILD_ARGS) --values $(ROOT_DIR)/values/$(ARCH).yaml --tree=$(TREE) $(PACKAGES) --backend $(BACKEND) --concurrency $(CONCURRENCY) --compression $(COMPRESSION)
-
-build-all: clean
-	mkdir -p $(ROOT_DIR)/build
-	$(SUDO) $(LUET) build $(BUILD_ARGS) --values $(ROOT_DIR)/values/$(ARCH).yaml --tree=$(TREE) --all --backend $(BACKEND) --concurrency $(CONCURRENCY) --compression $(COMPRESSION)
-
-rebuild:
-	$(SUDO) $(LUET) build $(BUILD_ARGS) --values $(ROOT_DIR)/values/$(ARCH).yaml --tree=$(TREE) $(PACKAGES) --backend $(BACKEND) --concurrency $(CONCURRENCY) --compression $(COMPRESSION)
-
-rebuild-all:
-	$(SUDO) $(LUET) build $(BUILD_ARGS) --values $(ROOT_DIR)/values/$(ARCH).yaml --tree=$(TREE) --all --backend $(BACKEND) --concurrency $(CONCURRENCY) --compression $(COMPRESSION)
-
-rebuild-full:
-	$(SUDO) $(LUET) build $(BUILD_ARGS) --values $(ROOT_DIR)/values/$(ARCH).yaml --tree=$(TREE) --full --backend $(BACKEND) --concurrency $(CONCURRENCY) --compression $(COMPRESSION)
-
-build-full: clean
-	mkdir -p $(ROOT_DIR)/build
-	$(SUDO) $(LUET) build $(BUILD_ARGS) --values $(ROOT_DIR)/values/$(ARCH).yaml --tree=$(TREE) --full --backend $(BACKEND) --concurrency $(CONCURRENCY) --compression $(COMPRESSION)
+build:
+	$(LUET) build $(BUILD_ARGS) \
+	--values $(ROOT_DIR)/values/$(ARCH).yaml \
+	--tree=$(TREE) $(PACKAGES) \
+	--backend $(BACKEND) \
+	--concurrency $(CONCURRENCY) \
+	--compression $(COMPRESSION)
 
 create-repo:
-	$(SUDO) $(LUET) create-repo --tree "$(TREE)" \
+	$(LUET) create-repo --tree "$(TREE)" \
     --output $(DESTINATION) \
     --packages $(DESTINATION) \
     --name "cOS" \
@@ -64,7 +63,7 @@ create-repo:
     --type http
 
 publish-repo:
-	$(SUDO) $(LUET) create-repo --tree "$(TREE)" \
+	$(LUET) create-repo --tree "$(TREE)" \
     --output $(FINAL_REPO) \
     --packages $(DESTINATION) \
     --name "cOS" \
@@ -77,20 +76,20 @@ publish-repo:
     --type docker
 
 serve-repo:
-	LUET_NOLOCK=true $(LUET) serve-repo --port 8000 --dir $(ROOT_DIR)/build &
+	LUET_NOLOCK=true $(LUET) serve-repo --port 8000 --dir $(ROOT_DIR)/build
 
 auto-bump:
 	TREE_DIR=$(ROOT_DIR) $(LUET) autobump-github
 
-autobump: auto-bump
-
 validate:
 	$(LUET) tree validate --tree $(TREE) $(VALIDATE_OPTIONS)
 
-local-iso: create-repo
-	$(SUDO) touch $(ROOT_DIR)/build/conf.yaml || true
-	$(SUDO) yq w -i $(ROOT_DIR)/build/conf.yaml 'repositories[0].name' 'local'
-	$(SUDO) yq w -i $(ROOT_DIR)/build/conf.yaml 'repositories[0].type' 'disk'
-	$(SUDO) yq w -i $(ROOT_DIR)/build/conf.yaml 'repositories[0].enable' true
-	$(SUDO) yq w -i $(ROOT_DIR)/build/conf.yaml 'repositories[0].urls[0]' $(DESTINATION)
-	$(SUDO) luet geniso-isospec $(ROOT_DIR)/iso/cOS-local.yaml
+$(ROOT_DIR)/build/conf.yaml:
+	touch $(ROOT_DIR)/build/conf.yaml
+	yq w -i $(ROOT_DIR)/build/conf.yaml 'repositories[0].name' 'local'
+	yq w -i $(ROOT_DIR)/build/conf.yaml 'repositories[0].type' 'disk'
+	yq w -i $(ROOT_DIR)/build/conf.yaml 'repositories[0].enable' true
+	yq w -i $(ROOT_DIR)/build/conf.yaml 'repositories[0].urls[0]' $(DESTINATION)
+
+local-iso: create-repo $(ROOT_DIR)/build/conf.yaml
+	 $(LUET) geniso-isospec $(ISO_SPEC)

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -9,8 +9,8 @@
 ### Building ISO
 
 - Luet-devkit (If you manually installed luet add the [official luet-repo](https://github.com/Luet-lab/luet-repo) first. Install it with `luet install -y system/luet-devkit`)
-- squashfs/xorriso/dosfstools for building ISO
-- yq (`luet install -y repository/mocaccino-extra-stable && luet install -y utils/yq`)
+- squashfs/xorriso/dosfstools for building ISO ( from your OS )
+- yq and jq (`luet install -y repository/mocaccino-extra-stable && luet install -y utils/yq utils/yq`)
 
 ## Repository layout
 
@@ -22,12 +22,12 @@
 ## Build all packages locally
 
 ```
-make build-full
+make build
 ```
 
-To rebuild packages, and keep the previous runs, use `make rebuild-full` instead.
+To clean from previous runs, run `make clean`.
 
-You might want to build packages running as `root` or define `SUDO="sudo -E"` if you intend to preserve file permissions in the resulting packages (mainly for `xattrs`, and so on).
+You might want to build packages running as `root` or `sudo -E` if you intend to preserve file permissions in the resulting packages (mainly for `xattrs`, and so on).
 
 ## Build ISO
 
@@ -49,10 +49,10 @@ To test changes against a specific set of packages, you can for example:
 
 ```bash
 
-SUDO="sudo -E" PACKAGES="live/init" make rebuild local-iso
+make PACKAGES="live/init"  build local-iso
 
 ```
 
-SUDO is used because we want to keep permissions on the output packages (not really required for experimenting).
+root is required because we want to keep permissions on the output packages (not really required for experimenting).
 
 Note: Remind to bump `definition.yaml` files where necessary, otherwise it would generate packages from existing images


### PR DESCRIPTION
Drop rebuild-full and rebuild-all. Keeps only `make build `.

It also drops `SUDO`, we now warn about it and let the user decide. The exception is `make deps` which requires root to install the binaries locally.

By defaults takes the packages to build from the given ISO_SPEC file, defaulting
to cOS-local.yaml which we use currently

Related to #32