### PR TITLE
Handle install and upgrades from single images

### DIFF
--- a/packages/cos/build.yaml
+++ b/packages/cos/build.yaml
@@ -117,6 +117,7 @@ excludes:
 - ^/usr/local/sbin
 - ^/usr/local/share
 - ^/usr/local/src
+- ^/usr/local/games
 
 # Some golang package leftovers
 - ^/root/.cache

--- a/packages/cos/definition.yaml
+++ b/packages/cos/definition.yaml
@@ -1,5 +1,5 @@
 name: "cos"
 category: "system"
-version: "0.4.15"
+version: "0.4.16"
 
 brand_name: "cOS"

--- a/packages/cos/grub.cfg
+++ b/packages/cos/grub.cfg
@@ -6,18 +6,21 @@ set gfxmode=auto
 set gfxpayload=keep
 insmod all_video
 insmod gfxterm
-
 menuentry "cOS" --id cos {
-  search.fs_label COS_ACTIVE root
+  search.fs_label COS_STATE root
+  set img=/cOS/active.img
+  loopback loop0 /$img
   set root=($root)
-  linux /boot/vmlinuz console=tty1 ro root=LABEL=COS_ACTIVE panic=5
-  initrd /boot/initrd
+  linux (loop0)/boot/vmlinuz console=tty1 ro root=LABEL=COS_ACTIVE iso-scan/filename=/cOS/active.img panic=5
+  initrd (loop0)/boot/initrd
 }
 
 menuentry "cOS (fallback)" --id fallback {
-  search.fs_label COS_PASSIVE root
+  search.fs_label COS_STATE root
+  set img=/cOS/passive.img
+  loopback loop0 /$img
   set root=($root)
-  linux /boot/vmlinuz console=tty1 ro root=LABEL=COS_PASSIVE panic=5
-  initrd /boot/initrd
+  linux (loop0)/boot/vmlinuz console=tty1 ro root=LABEL=COS_PASSIVE iso-scan/filename=/cOS/passive.img panic=5
+  initrd (loop0)/boot/initrd
 }
 

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -36,7 +36,7 @@ usage()
     echo ""
     echo "Example: $PROG /dev/vda"
     echo ""
-    echo "DEVICE must be the disk that will be partitioned (/dev/vda). If you are using --no-format it should be the device of the COS_ACTIVE partition (/dev/vda2)"
+    echo "DEVICE must be the disk that will be partitioned (/dev/vda). If you are using --no-format it should be the device of the COS_STATE partition (/dev/vda2)"
     echo ""
     echo "The parameters names refer to the same names used in the cmdline, refer to README.md for"
     echo "more info."
@@ -47,15 +47,13 @@ usage()
 do_format()
 {
     if [ "$COS_INSTALL_NO_FORMAT" = "true" ]; then
-        STATE=$(blkid -L COS_ACTIVE || true)
+        STATE=$(blkid -L COS_STATE || true)
         if [ -z "$STATE" ] && [ -n "$DEVICE" ]; then
-            tune2fs -L COS_ACTIVE $DEVICE
-            STATE=$(blkid -L COS_ACTIVE)
+            tune2fs -L COS_STATE $DEVICE
+            STATE=$(blkid -L COS_STATE)
         fi
         OEM=$(blkid -L COS_OEM || true)
-        STATE=$(blkid -L COS_ACTIVE || true)
-        PERSISTENT=$(blkid -L COS_PERSISTENT || true)
-        PASSIVE=$(blkid -L COS_PASSIVE || true)
+        STATE=$(blkid -L COS_STATE || true)
         BOOT=$(blkid -L COS_GRUB || true)
         return 0
     fi
@@ -66,26 +64,24 @@ do_format()
         BOOT_NUM=1
         OEM_NUM=2
         STATE_NUM=3
-        PASSIVE_NUM=4
-        PERSISTENT_NUM=5
+        PERSISTENT_NUM=4
         parted -s ${DEVICE} mkpart primary fat32 0% 50MB # efi
         parted -s ${DEVICE} mkpart primary ext4 50MB 100MB # oem
-        parted -s ${DEVICE} mkpart primary ext4 100MB 2100MB # active
-        parted -s ${DEVICE} mkpart primary ext4 2100MB 4100MB # passive
-        parted -s ${DEVICE} mkpart primary ext4 4100MB 100% # persistent
+        parted -s ${DEVICE} mkpart primary ext4 100MB 20100MB # active
+        parted -s ${DEVICE} mkpart primary ext4 20100MB 100% # persistent
+        parted -s ${DEVICE} set 1 ${BOOTFLAG} on
+
     else
         BOOT_NUM=
         OEM_NUM=1
         STATE_NUM=2
-        PASSIVE_NUM=3
-        PERSISTENT_NUM=4
+        PERSISTENT_NUM=3
         parted -s ${DEVICE} mkpart primary ext4 0% 50MB # oem
-        parted -s ${DEVICE} mkpart primary ext4 50MB 2050MB # active
-        parted -s ${DEVICE} mkpart primary ext4 2050MB 4050MB # passive
-        parted -s ${DEVICE} mkpart primary ext4 4050MB 100% # persistent
+        parted -s ${DEVICE} mkpart primary ext4 50MB 20050MB # active
+        parted -s ${DEVICE} mkpart primary ext4 20050MB 100% # persistent
+        parted -s ${DEVICE} set 2 ${BOOTFLAG} on
     fi
-
-    parted -s ${DEVICE} set 1 ${BOOTFLAG} on
+   
     partprobe ${DEVICE} 2>/dev/null || true
     sleep 2
 
@@ -105,9 +101,8 @@ do_format()
     STATE=${PREFIX}${STATE_NUM}
     OEM=${PREFIX}${OEM_NUM}
     PERSISTENT=${PREFIX}${PERSISTENT_NUM}
-    PASSIVE=${PREFIX}${PASSIVE_NUM}
 
-    mkfs.ext4 -F -L COS_ACTIVE ${STATE}
+    mkfs.ext4 -F -L COS_STATE ${STATE}
     if [ -n "${BOOT}" ]; then
         mkfs.vfat -F 32 ${BOOT}
         fatlabel ${BOOT} COS_GRUB
@@ -115,18 +110,30 @@ do_format()
 
     mkfs.ext4 -F -L COS_OEM ${OEM}
     mkfs.ext4 -F -L COS_PERSISTENT ${PERSISTENT}
-    mkfs.ext4 -F -L COS_PASSIVE ${PASSIVE}
 }
 
 do_mount()
 {
     mkdir -p ${TARGET}
-    mount ${STATE} ${TARGET}
+
+    STATEDIR=/tmp/mnt/STATE
+    mkdir -p $STATEDIR || true
+    mount ${STATE} $STATEDIR
+
+    mkdir -p ${STATEDIR}/cOS
+    dd if=/dev/zero of=${STATEDIR}/cOS/active.img bs=1M count=3240
+    mkfs.ext4 ${STATEDIR}/cOS/active.img
+    tune2fs -L COS_ACTIVE ${STATEDIR}/cOS/active.img
+    mount -t ext4 -o loop ${STATEDIR}/cOS/active.img $TARGET
+
     mkdir -p ${TARGET}/boot
     if [ -n "${BOOT}" ]; then
         mkdir -p ${TARGET}/boot/efi
         mount ${BOOT} ${TARGET}/boot/efi
     fi
+    mkdir -p ${TARGET}/boot/grub2
+    mount ${STATE} ${TARGET}/boot/grub2
+
     mkdir -p ${TARGET}/oem
     mount ${OEM} ${TARGET}/oem
     mkdir -p ${TARGET}/usr/local

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -67,8 +67,8 @@ do_format()
         PERSISTENT_NUM=4
         parted -s ${DEVICE} mkpart primary fat32 0% 50MB # efi
         parted -s ${DEVICE} mkpart primary ext4 50MB 100MB # oem
-        parted -s ${DEVICE} mkpart primary ext4 100MB 20100MB # active
-        parted -s ${DEVICE} mkpart primary ext4 20100MB 100% # persistent
+        parted -s ${DEVICE} mkpart primary ext4 100MB 10100MB # active
+        parted -s ${DEVICE} mkpart primary ext4 10100MB 100% # persistent
         parted -s ${DEVICE} set 1 ${BOOTFLAG} on
 
     else
@@ -77,8 +77,8 @@ do_format()
         STATE_NUM=2
         PERSISTENT_NUM=3
         parted -s ${DEVICE} mkpart primary ext4 0% 50MB # oem
-        parted -s ${DEVICE} mkpart primary ext4 50MB 20050MB # active
-        parted -s ${DEVICE} mkpart primary ext4 20050MB 100% # persistent
+        parted -s ${DEVICE} mkpart primary ext4 50MB 10050MB # active
+        parted -s ${DEVICE} mkpart primary ext4 10050MB 100% # persistent
         parted -s ${DEVICE} set 2 ${BOOTFLAG} on
     fi
    

--- a/packages/installer/upgrade.sh
+++ b/packages/installer/upgrade.sh
@@ -82,18 +82,17 @@ upgrade() {
     mount_persistent
     ensure_dir_structure
 
-    mkdir -p /run/tmp
+    mkdir -p /usr/local/tmp/upgrade
     # FIXME: XDG_RUNTIME_DIR is for containerd, by default that points to /run/user/<uid>
     # which might not be sufficient to unpack images. Use /usr/local/tmp until we get a separate partition
     # for the state
     # FIXME: Define default /var/tmp as tmpdir_base in default luet config file
-    XDG_RUNTIME_DIR=/run/tmp TMPDIR=/run/tmp luet install -y $UPGRADE_IMAGE
+    XDG_RUNTIME_DIR=/usr/local/tmp/upgrade TMPDIR=/usr/local/tmp/upgrade luet install -y $UPGRADE_IMAGE
     luet cleanup
-    rm -rf /tmp/upgrade/var/tmp/*
-    rm -rf /run/tmp
-    umount $TARGET/oem || true
-    umount $TARGET/usr/local || true
-    umount $TARGET || true
+    rm -rf /usr/local/tmp/upgrade
+    umount $TARGET/oem
+    umount $TARGET/usr/local
+    umount $TARGET
 }
 
 switch_active() {
@@ -116,6 +115,7 @@ ensure_dir_structure() {
 
 cleanup2()
 {
+    rm -rf /usr/local/tmp/upgrade || true
     mount -o remount,ro ${STATE} ${STATEDIR} || true
     if [ -n "${TARGET}" ]; then
         umount ${TARGET}/boot/efi || true

--- a/packages/installer/upgrade.sh
+++ b/packages/installer/upgrade.sh
@@ -3,20 +3,15 @@ set -e
 # 1. Identify active/passive partition
 # 2. Install upgrade in passive partition
 # 3. Invert partition labels
-# 4. Update grub (?)
-# 5. Reboot if requested by user (?)
+# 4. Reboot if requested by user (?)
 
 find_partitions() {
-    ACTIVE=$(blkid -L COS_ACTIVE || true)
-    if [ -z "$ACTIVE" ]; then
-        echo "Active partition cannot be found"
+    STATE=$(blkid -L COS_STATE || true)
+    if [ -z "$STATE" ]; then
+        echo "State partition cannot be found"
         exit 1
     fi
-    PASSIVE=$(blkid -L COS_PASSIVE || true)
-    if [ -z "$ACTIVE" ]; then
-        echo "Active partition cannot be found"
-        exit 1
-    fi
+
     PERSISTENT=$(blkid -L COS_PERSISTENT || true)
     if [ -z "$PERSISTENT" ]; then
         echo "Persistent partition cannot be found"
@@ -28,50 +23,27 @@ find_partitions() {
         exit 1
     fi
 
-    CURRENT=$(df $0 | tail -1 | gawk '{print $1}')
-    if [ -z "$CURRENT" ]; then
-        echo "Could not determine current partition"
-        exit 1
-    fi
-    if [ -z "$ACTIVE" ]; then
-        echo "Could not determine active partition"
-        exit 1
-    fi
-    if [ -z "$PASSIVE" ]; then
-        echo "Could not determine passive partition"
-        exit 1
+    COS_ACTIVE=$(blkid -L COS_ACTIVE || true)
+    if [ -n "$COS_ACTIVE" ]; then
+        CURRENT=active.img
     fi
 
-    if [[ $CURRENT == $ACTIVE ]]; then
-        TARGET_PARTITION=$PASSIVE
-        NEW_ACTIVE=$PASSIVE
-        NEW_PASSIVE=$ACTIVE
-    elif [[ $CURRENT == $PASSIVE ]]; then
-        # We booted from the fallback, and we are attempting to fixup the active one
-        TARGET_PARTITION=$ACTIVE
-        NEW_ACTIVE=$ACTIVE
-        NEW_PASSIVE=$PASSIVE
-    elif [ -z "$TARGET_PARTITION" ]; then
+    COS_PASSIVE=$(blkid -L COS_PASSIVE || true)
+    if [ -n "$COS_PASSIVE" ]; then
+        CURRENT=passive.img
+    fi
+
+    if [ -z "$CURRENT" ]; then
         # We booted from an ISO or some else medium. We assume we want to fixup the current label
         read -p "Could not determine current partition. Set TARGET_PARTITION, NEW_ACTIVE and NEW_PASSIVE. Otherwise assuming you want to overwrite COS_ACTIVE? [y/N] : " -n 1 -r
         if [[ ! $REPLY =~ ^[Yy]$ ]]
         then
             [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
         fi
-        TARGET_PARTITION=$ACTIVE
-        NEW_ACTIVE=$ACTIVE
-        NEW_PASSIVE=$PASSIVE
+        CURRENT=active.img
     fi
 
-    if [ -z "$TARGET_PARTITION" ]; then
-        echo "Could not determine target partition. Set TARGET_PARTITION, NEW_ACTIVE and NEW_PASSIVE"
-        exit 1
-    fi
-
-    echo "-> Partition labeled COS_ACTIVE: $ACTIVE"
-    echo "-> Partition labeled COS_PASSIVE: $PASSIVE"
     echo "-> Booting from: $CURRENT"
-    echo "-> Target upgrade partition: $TARGET_PARTITION"
 }
 
 # cos-upgrade-image: system/cos
@@ -84,9 +56,19 @@ find_upgrade_channel() {
 }
 
 mount_image() {
+    STATEDIR=/run/initramfs/isoscan
     TARGET=/tmp/upgrade
-    mkdir ${TARGET} || true
-    mount $TARGET_PARTITION ${TARGET}
+
+    mkdir -p $TARGET || true
+    # mkdir -p $STATEDIR || true
+    # mount ${STATE} $STATEDIR
+    mount -o remount,rw ${STATE} ${STATEDIR}
+
+    mkdir -p ${STATEDIR}/cOS || true
+    rm -rf ${STATEDIR}/cOS/transition.img || true
+    dd if=/dev/zero of=${STATEDIR}/cOS/transition.img bs=1M count=3240
+    mkfs.ext4 ${STATEDIR}/cOS/transition.img
+    mount -t ext4 -o loop ${STATEDIR}/cOS/transition.img $TARGET
 }
 
 mount_persistent() {
@@ -94,40 +76,35 @@ mount_persistent() {
     mount ${OEM} ${TARGET}/oem
     mkdir -p ${TARGET}/usr/local || true
     mount ${PERSISTENT} ${TARGET}/usr/local
-    GRUB=$(blkid -L COS_GRUB || true)
-    if [ -n "$GRUB" ]; then
-        mkdir -p ${TARGET}/boot/efi || true
-        mount ${GRUB} ${TARGET}/boot/efi
-    fi
 }
 
 upgrade() {
     mount_image
-
-    # XXX: Wipe old, needed until we have a persistent luet state.
-    # TODO: at least cache downloads before wiping and we are sure we can perform the new install
-    if [ -d "/tmp/empty" ]; then
-        rm -rf /tmp/empty
-    fi
-    mkdir /tmp/empty
-    rsync -a --delete /tmp/empty/ /tmp/upgrade/
-
     mount_persistent
     ensure_dir_structure
+
+    mkdir -p /run/tmp
     # FIXME: XDG_RUNTIME_DIR is for containerd, by default that points to /run/user/<uid>
     # which might not be sufficient to unpack images. Use /usr/local/tmp until we get a separate partition
     # for the state
     # FIXME: Define default /var/tmp as tmpdir_base in default luet config file
-    XDG_RUNTIME_DIR=/var/tmp TMPDIR=/var/tmp luet install -y $UPGRADE_IMAGE
+    XDG_RUNTIME_DIR=/run/tmp TMPDIR=/run/tmp luet install -y $UPGRADE_IMAGE
     luet cleanup
     rm -rf /tmp/upgrade/var/tmp/*
+    rm -rf /run/tmp
+    umount $TARGET/oem || true
+    umount $TARGET/usr/local || true
+    umount $TARGET || true
 }
 
 switch_active() {
-    echo "-> Flagging $NEW_ACTIVE as COS_ACTIVE"
-    tune2fs -L COS_ACTIVE $NEW_ACTIVE
-    echo "-> Flagging $NEW_PASSIVE as COS_PASSIVE"
-    tune2fs -L COS_PASSIVE $NEW_PASSIVE
+    if [[ "$CURRENT" == "active.img" ]]; then
+        mv -f ${STATEDIR}/cOS/$CURRENT ${STATEDIR}/cOS/passive.img
+        tune2fs -L COS_PASSIVE ${STATEDIR}/cOS/passive.img
+    fi
+
+    mv -f ${STATEDIR}/cOS/transition.img ${STATEDIR}/cOS/active.img
+    tune2fs -L COS_ACTIVE ${STATEDIR}/cOS/active.img
 }
 
 ensure_dir_structure() {
@@ -138,16 +115,9 @@ ensure_dir_structure() {
     mkdir ${TARGET}/tmp || true
 }
 
-update_grub() {
-    if [ -e "/sys/firmware/efi" ]; then
-        GRUB_TARGET="--target=x86_64-efi --efi-dir=${TARGET}/boot/efi"
-    fi
-    DEVICE=/dev/$(lsblk -no pkname ${TARGET_PARTITION})
-    grub2-install ${GRUB_TARGET} --removable ${DEVICE}
-}
-
 cleanup2()
 {
+    mount -o remount,ro ${STATE} ${STATEDIR} || true
     if [ -n "${TARGET}" ]; then
         umount ${TARGET}/boot/efi || true
         umount ${TARGET}/oem || true
@@ -172,12 +142,6 @@ trap cleanup exit
 upgrade
 
 switch_active
-
-# FIXME: We have to regenerate grub since now we don't have a partition for /boot/grub2. upgrades,
-# since don't have any state and wipe everything, will remove generated grub files during install
-# NOTE: If we have a persistent luetdb state, this wouldnt be required, because handled by upgrades
-# (no wipe needed).
-update_grub
 
 echo "Flush changes to disk"
 sync

--- a/packages/installer/upgrade.sh
+++ b/packages/installer/upgrade.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
+
 # 1. Identify active/passive partition
 # 2. Install upgrade in passive partition
 # 3. Invert partition labels
-# 4. Reboot if requested by user (?)
 
 find_partitions() {
     STATE=$(blkid -L COS_STATE || true)
@@ -17,6 +17,7 @@ find_partitions() {
         echo "Persistent partition cannot be found"
         exit 1
     fi
+
     OEM=$(blkid -L COS_OEM || true)
     if [ -z "$OEM" ]; then
         echo "OEM partition cannot be found"
@@ -35,7 +36,7 @@ find_partitions() {
 
     if [ -z "$CURRENT" ]; then
         # We booted from an ISO or some else medium. We assume we want to fixup the current label
-        read -p "Could not determine current partition. Set TARGET_PARTITION, NEW_ACTIVE and NEW_PASSIVE. Otherwise assuming you want to overwrite COS_ACTIVE? [y/N] : " -n 1 -r
+        read -p "Could not determine current partition. Do you want to overwrite your current active partition? [y/N] : " -n 1 -r
         if [[ ! $REPLY =~ ^[Yy]$ ]]
         then
             [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
@@ -60,8 +61,6 @@ mount_image() {
     TARGET=/tmp/upgrade
 
     mkdir -p $TARGET || true
-    # mkdir -p $STATEDIR || true
-    # mount ${STATE} $STATEDIR
     mount -o remount,rw ${STATE} ${STATEDIR}
 
     mkdir -p ${STATEDIR}/cOS || true


### PR DESCRIPTION
Instead of having an ACTIVE and PASSIVE partition, we have ACTIVE and
PASSIVE .img file that we swap during upgrade. The flipping happens between `/cOS/active.img` and `/cOS/passive.img`, and a transition image which is being created during the upgrade process.

This is far more robust and less failure prone and doesn't involve
anymore grub installation during upgrades.