### PR TITLE
Require /oem mount point for cos-setup-fs.service

### DIFF
--- a/packages/base-conf/definition.yaml
+++ b/packages/base-conf/definition.yaml
@@ -1,3 +1,3 @@
 name: "base-conf"
 category: "system"
-version: "0.0.2"
+version: "0.0.4"

--- a/packages/base-conf/fstab
+++ b/packages/base-conf/fstab
@@ -1,2 +1,2 @@
-LABEL=COS_PERSISTENT    /usr/local  auto    nofail,x-systemd.device-timeout=1ms,x-systemd.requires-mounts-for=/etc,x-systemd.wanted-by=local-fs.target    0  2
-LABEL=COS_OEM           /oem        auto    nofail,x-systemd.device-timeout=1ms,x-systemd.requires-mounts-for=/etc,x-systemd.wanted-by=local-fs.target    0  2
+LABEL=COS_PERSISTENT    /usr/local  auto    nofail,x-systemd.device-timeout=5s,x-systemd.wanted-by=local-fs.target,x-systemd.wanted-by=cos-setup-fs.service    0  2
+LABEL=COS_OEM           /oem        auto    nofail,x-systemd.device-timeout=5s,x-systemd.wanted-by=local-fs.target,x-systemd.wanted-by=cos-setup-fs.service    0  2


### PR DESCRIPTION
This commit adds a dependency of cos-setup-fs.service with the /oem mount
point. In addition the timeout of the /oem and /usr/local is raised a
little so it is really unlikely they are missed on the first attempt to
mount them and their dependency to /etc is dropped. In fact we do not
care about what is mounted first /etc or /oem, we care that both are
mounted when cos-setup-fs.service is executed.