### PR TITLE
cOS reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Run `cos-installer <device>` to start the installation process. Remove the ISO a
 
 _Note_: `cos-installer` supports other options as well. Run `cos-installer --help` to see a complete help.
 
-## Upgrades / reset:
+## Upgrades:
 
 To upgrade the system, just run `cos-upgrade` and reboot.
 
@@ -42,9 +42,16 @@ cOS during installation sets two `.img` images files in the `COS_STATE` partitio
 
 Those are used by the upgrade mechanism to prepare and install a pristine `cOS` each time an upgrade is attempted.
 
-## Recovery
+## Reset state
 
-The ISO can be also used as a recovery medium: type `cos-upgrade` from a LiveCD. It will then try to reset the state of the active partition.
+### Recovery partition
+
+cOS can be recovered anytime from the `cOS recovery` partition by running `cos-reset`. This will regenerate the bootloader and the images in `COS_STATE` by using the recovery image created during installation.
+
+The recovery partition can also be upgraded by running `UPGRADE_RECOVERY=true cos-upgrade` in the standard partitions used for boot.
+
+### From ISO
+The ISO can be also used as a recovery medium: type `cos-upgrade` from a LiveCD. It will then try to upgrade the image of the active partition installed in the system.
 
 ## File system layout
 

--- a/packages/cloud-config/definition.yaml
+++ b/packages/cloud-config/definition.yaml
@@ -1,3 +1,3 @@
 name: cloud-config
 category: system
-version: "0.4.20"
+version: "0.4.21"

--- a/packages/cloud-config/yipfiles/06_recovery.yaml
+++ b/packages/cloud-config/yipfiles/06_recovery.yaml
@@ -1,0 +1,19 @@
+# Default cOS OEM configuration file
+#
+# This file is part of cOS and will get reset during upgrades.
+#
+# Before you change this file manually,
+# consider copying this file to /usr/local/cloud-config or
+# copy the file with a prefix starting by 90, e.g. /oem/91_custom.yaml
+
+stages:
+   boot:
+     - name: "Recovery"
+       commands:
+       - |
+            source /etc/os-release
+            if [ -n "$(blkid -L COS_SYSTEM || true)" ]; then
+                echo >> /etc/issue
+                echo "You are booting from recovery mode. Run 'cos-reset' to reset the system to $VERSION" >> /etc/issue
+                echo >> /etc/issue
+            fi

--- a/packages/cos/definition.yaml
+++ b/packages/cos/definition.yaml
@@ -1,5 +1,5 @@
 name: "cos"
 category: "system"
-version: "0.4.17"
+version: "0.4.18"
 
 brand_name: "cOS"

--- a/packages/cos/grub.cfg
+++ b/packages/cos/grub.cfg
@@ -24,3 +24,11 @@ menuentry "cOS (fallback)" --id fallback {
   initrd (loop0)/boot/initrd
 }
 
+menuentry "cOS recovery" --id recovery {
+  search.fs_label COS_RECOVERY root
+  set img=/cOS/recovery.img
+  loopback loop0 /$img
+  set root=($root)
+  linux (loop0)/boot/vmlinuz console=tty1 ro root=LABEL=COS_SYSTEM iso-scan/filename=/cOS/recovery.img panic=5
+  initrd (loop0)/boot/initrd
+}

--- a/packages/installer/build.yaml
+++ b/packages/installer/build.yaml
@@ -6,4 +6,4 @@ requires:
 steps:
 - cp -rfv installer.sh /usr/sbin/cos-installer && chmod +x /usr/sbin/cos-installer
 - cp -rfv upgrade.sh /usr/sbin/cos-upgrade && chmod +x /usr/sbin/cos-upgrade
-
+- cp -rfv reset.sh /usr/sbin/cos-reset && chmod +x /usr/sbin/cos-reset

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: "0.6.15"
+version: "0.6.16"

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -18,9 +18,10 @@ cleanup2()
         umount ${TARGET}/dev || true
         umount ${TARGET}/sys || true
         umount ${TARGET}/boot/efi || true
+        umount ${TARGET}/boot/grub2 || true
         umount ${TARGET} || true
-
     fi
+    umount ${STATEDIR} || true
 }
 
 cleanup()
@@ -270,11 +271,6 @@ validate_device()
     fi
 }
 
-create_opt()
-{
-    mkdir -p "${TARGET}/cos/data/opt"
-}
-
 while [ "$#" -gt 0 ]; do
     case $1 in
         --no-format)
@@ -338,7 +334,6 @@ do_format
 do_mount
 do_copy
 install_grub
-create_opt
 
 if [ -n "$INTERACTIVE" ]; then
     exit 0

--- a/packages/installer/reset.sh
+++ b/packages/installer/reset.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -e
+
+# FIXME: should have two ways for resetting
+# - easiest/reliable: copy 1:1 RECOVERY partition. 
+#   cOS just detecting if it's running by recovery partition should be able to behave differently
+# - less repro, but keeps things up-to-date: rerun installation steps into COS_STATE. 
+#   But what upgrades the recovery mechanism itself remains an open point. It should be run as part of cos-upgrade, maybe with a flag.
+# At the moment cos-reset is implementing the latter as we don't have a recovery partition (yet).
+
+find_partitions() {
+    STATE=$(blkid -L COS_STATE || true)
+    if [ -z "$STATE" ]; then
+        echo "State partition cannot be found"
+        exit 1
+    fi
+    DEVICE=/dev/$(lsblk -no pkname $STATE)
+
+    BOOT=$(blkid -L COS_GRUB || true)
+}
+
+do_mount()
+{
+    STATEDIR=/run/initramfs/isoscan
+    mount -o remount,rw ${STATE} ${STATEDIR}
+
+    if [ -n "${BOOT}" ]; then
+        mkdir -p /boot/efi || true
+        mount ${BOOT} /boot/efi
+    fi
+    mkdir -p /boot/grub2 || true
+    mount ${STATE} /boot/grub2
+}
+
+cleanup2()
+{  
+    umount /boot/efi || true
+    umount /boot/grub2 || true
+    mount -o remount,ro ${STATE} ${STATEDIR} || true
+}
+
+cleanup()
+{
+    EXIT=$?
+    cleanup2 2>/dev/null || true
+    return $EXIT
+}
+
+install_grub()
+{
+    mount -o remount,rw ${STATE} /boot/grub2
+    grub2-install ${DEVICE}
+}
+
+reset() {
+    rm -rf /oem/*
+    rm -rf /usr/local/*
+}
+
+copy_active() {
+    mount -o remount,rw ${STATE} ${STATEDIR}
+    cp -rf ${STATEDIR}/cOS/active.img ${STATEDIR}/cOS/passive.img
+    tune2fs -L COS_PASSIVE ${STATEDIR}/cOS/passive.img
+}
+
+trap cleanup exit
+
+find_partitions
+do_mount
+
+if [ -n "$PERSISTENCE_RESET" ] && [ "$PERSISTENCE_RESET" == "true" ]; then
+    reset
+fi
+
+CURRENT=passive.img cos-upgrade
+
+install_grub
+
+copy_active

--- a/packages/luet/definition.yaml
+++ b/packages/luet/definition.yaml
@@ -4,3 +4,4 @@ version: "0.11.2"
 labels:
   github.repo: "luet"
   github.owner: "mudler"
+  autobump.revdeps: "false"

--- a/packages/yip/definition.yaml
+++ b/packages/yip/definition.yaml
@@ -4,3 +4,4 @@ version: "0.7.2"
 labels:
   github.repo: "yip"
   github.owner: "mudler"
+  autobump.revdeps: "false"


### PR DESCRIPTION
This PR introduces a recovery partition which is prepared during install (`COS_RECOVERY`). It can be used later to restore the system as it was at install time, by running `cos-reset` ( when booting from recovery ). 

An initial implementation allowed also to reset a system from the version available in the repositories, but after thinking about it I realized it's not really needed, as the user should be able to do that by running `cos-upgrade` (and use the recovery to get back to a _known_ working state).

It is also possible to update the recovery partition running `cos-upgrade` on the running system (not the recovery) by setting `UPGRADE_RECOVERY=true`. We require 8 gigs for the recovery partition to be sure to have enough
space to update it.

Fixes #64 and fixes #63 