### PR TITLE
Move system OEM files to /system/oem

### DIFF
--- a/packages/cloud-config/build.yaml
+++ b/packages/cloud-config/build.yaml
@@ -3,6 +3,6 @@ requires:
   category: "system"
   version: ">=0"
 steps:
-- mkdir -p /oem
-- cp -rfv yipfiles/*.yaml /oem
-- chmod -R 600 /oem
+- mkdir -p /system/oem
+- cp -rfv yipfiles/*.yaml /system/oem
+- chmod -R 600 /system/oem

--- a/packages/cloud-config/definition.yaml
+++ b/packages/cloud-config/definition.yaml
@@ -1,3 +1,3 @@
 name: cloud-config
 category: system
-version: "0.4.21"
+version: "0.4.22"

--- a/packages/cos-setup/cos-setup
+++ b/packages/cos-setup/cos-setup
@@ -14,7 +14,7 @@ for x in "$@"; do
     esac
 done
 
-for dir in "/oem/" "/usr/local/cloud-config/"; do
+for dir in "/system/oem" "/oem/" "/usr/local/cloud-config/"; do
     if [ -d "$dir" ]; then
         yip -s "$STAGE".before "$dir"
         yip -s "$STAGE" "$dir"

--- a/packages/cos-setup/definition.yaml
+++ b/packages/cos-setup/definition.yaml
@@ -1,3 +1,3 @@
 name: cos-setup
 category: system
-version: "0.2.3"
+version: "0.2.4"


### PR DESCRIPTION
Those are defaults that should be never override directly from the user,
but rather be immutable. Previously they were replaced during upgrades,
but this has the disadvantage that fallback and standard boot share the
same OEM. In this way, each image ships their own oem which are
immutable , but will still leave /oem as persistent for oem changes.

Related to #24