### PR TITLE
Add audit package for Fedora variant

### DIFF
--- a/packages/base-conf/build.yaml
+++ b/packages/base-conf/build.yaml
@@ -11,5 +11,3 @@ steps:
 {{end}}
 - cp *.mount overlay-setup.service /etc/systemd/system/
 - systemctl enable overlay-setup.service
-- echo "{{.Values.is_fedora}}"
-- echo "{{.Values.is_opensuse}}"

--- a/values/fedora.yaml
+++ b/values/fedora.yaml
@@ -9,6 +9,7 @@ fedora_packages: >-
     squashfs-tools
     dracut-live
     efibootmgr
+    audit
 
 kernel_package: kernel
 kernel_version: "5.10.19"


### PR DESCRIPTION
This commit adds `audit` package for Fedora based variant in order to
avoid audit logs to be redirected to stderr by default.